### PR TITLE
New priceid-sell plugin

### DIFF
--- a/interhack.pl
+++ b/interhack.pl
@@ -950,6 +950,14 @@ while (1)
   }
 
   $topline = $vt->row_plaintext(1);
+  if ($vt->row_plaintext(2) =~ /--More--\s*$/){
+	  $topline=~s/ *$/ /;
+	  $topline.=$vt->row_plaintext(2);
+	  $topline=~s/--More--\s*$//;
+  }elsif ($vt->row_plaintext(2) =~ /\[ynaq\] \([yn]\)\s*$/){
+	  $topline=~s/ *$/ /;
+	  $topline.=$vt->row_plaintext(2);
+  };
   study $topline;
 
   unless ($stop_sing_pass)

--- a/plugins/priceid-buy.pl
+++ b/plugins/priceid-buy.pl
@@ -84,7 +84,7 @@ our %price_table =
 		  },
   'cloak' => {
               50 => ['displacement', 'protection'],
-              50 => ['invisibility', 'magic resistance'],
+              60 => ['invisibility', 'magic resistance'],
 		  },
 );
 

--- a/plugins/priceid-buy.pl
+++ b/plugins/priceid-buy.pl
@@ -69,6 +69,23 @@ our %price_table =
                       'teleportation'],
               500 => ['death', 'wishing'],
           },
+  'boots' => {
+              10 => ['elven', 'kicking'],
+              30 => ['fumble', 'levitation'],
+              50 => ['jumping', 'speed', 'water walking'],
+		  },
+  'helmet' => {
+              10 => ['plain'],
+              50 => ['brilliance', 'opp.align', 'telepathy'],
+		  },
+  'gloves' => {
+               8 => ['leather'],
+              50 => ['dexterity', 'fumbling', 'power'],
+		  },
+  'cloak' => {
+              50 => ['displacement', 'protection'],
+              50 => ['invisibility', 'magic resistance'],
+		  },
 );
 
 our $shirt = 0;
@@ -132,7 +149,7 @@ make_tab qr/^(?:You have a little trouble lifting )?(.) - (an?|\d+) (?:clear pot
              "\e\e#name\ny$letter$buc\n";
          };
 
-make_tab qr/^(?:You have a little trouble lifting )?(.) - (an?|\d+) (?:blessed |uncursed |cursed )?(.*?) ?(scroll|potion|wand|ring|spellbook)s? (?:(?:called |labeled )(.*?) ?)?\(unpaid, (\d+) zorkmids?\)\./
+make_tab qr/^(?:You have a little trouble lifting )?(.) - (an?|\d+) (?:blessed |uncursed |cursed )?(?:pair of )?(.*?) ?(scroll|potion|wand|ring|spellbook|boots|helmet|gloves)s? (?:(?:called |labeled )(.*?) ?)?\(unpaid, (\d+) zorkmids?\)\./
       => sub
          {
              my ($letter, $count, $appearance, $type, $existing, $cost)

--- a/plugins/priceid-sell.pl
+++ b/plugins/priceid-sell.pl
@@ -32,12 +32,12 @@ sub do_sell_id {
 		$sale = int ($price/3) if ($role eq 'Tou' && $xlvl <= 15) || $shirt;
 		if ($amount == $sale){
 			push @prices,$price;
-			push @possibilities, @{$obj{$price}};
+			push @possibilities, @{$short_names{$type}{$price}||$obj{$price}};
 		};
 		$sale=int($sale*3/4 +0.5); # round up
 		if ($amount == $sale){
 			push @prices,$price;
-			push @possibilities, @{$obj{$price}};
+			push @possibilities, @{$short_names{$type}{$price}||$obj{$price}};
 		};
 	};
 	my $cost=join"/",@prices;

--- a/plugins/priceid-sell.pl
+++ b/plugins/priceid-sell.pl
@@ -58,6 +58,11 @@ sub do_sell_id {
 			$tab="\e,\e#name\nn${slot}${appearance} ${name}\n";
 			$txt.=" [TAB to name it]";
 		};
+		if(!$sell_id_tab_nice){
+			$txt="Press tab to send the string: $tab";
+			$txt =~ s/\n/\\n/g;
+			$txt =~ s/\e/\\e/g;
+		};
 	}
 	annotate($txt);
 };

--- a/plugins/priceid-sell.pl
+++ b/plugins/priceid-sell.pl
@@ -1,0 +1,67 @@
+# Does price-identification when selling
+
+# Options:
+# $sell_id_tab=1  -  makes TAB name the item (not very tested yet)
+# $sell_id_uniq=1 -  makes TAB pickup and drop the item again
+#                    iff the price quote is not unique.
+
+include "priceid-buy";
+
+our ($sell_id_tab,$sell_id_uniq);
+
+sub getslot {
+	if (alphakeys(-2) eq "d"){
+		return alphakeys(-1);
+	};
+	if (alphakeys(-3) eq "d" && alphakeys(-1) eq " "){
+		return alphakeys(-2);
+	};
+    return "-";
+}
+
+
+sub do_sell_id {
+	my ($amount,$appearance,$type)=@_;
+	my $slot=getslot();
+
+	my %obj=%{$price_table{$type}};
+
+	my (@prices,@possibilities);
+	for my $price (keys %obj){
+		my $sale=int ($price /2);
+		$sale = int ($price/3) if ($role eq 'Tou' && $xlvl <= 15) || $shirt;
+		if ($amount == $sale){
+			push @prices,$price;
+			push @possibilities, @{$obj{$price}};
+		};
+		$sale=int($sale*3/4 +0.5); # round up
+		if ($amount == $sale){
+			push @prices,$price;
+			push @possibilities, @{$obj{$price}};
+		};
+	};
+	my $cost=join"/",@prices;
+	$cost=~ s/00//g if ($type eq "spellbook");
+	my $name;
+	if (@possibilities <= 3){
+		$name =join '/', @possibilities;
+	} else { 
+		$name = $cost;
+	};
+	
+	my $txt="SELL-ID: $type($appearance) $name";
+	if ($sell_id_tab && $slot =~ /^[a-zA-Z]$/){
+		if(@prices == 2 && $sell_id_uniq){
+			$tab="\e,\ed${slot} ";
+			$txt.=" [TAB to try again]";
+		}else{
+			$tab="\e,\e#name\nn${slot}${appearance} ${name}\n";
+			$txt.=" [TAB to name it]";
+		};
+	}
+	annotate($txt);
+};
+
+each_match qr/offers (\d+) gold pieces for your (\w+) (spellbook|potion|ring|wand)\. +Sell it\?/ => sub { do_sell_id($1,$2,$3) };
+
+each_match qr/offers (\d+) gold pieces for your (scroll) labeled (.*?)\. +Sell it\?/ => sub { do_sell_id($1,$3,$2) };


### PR DESCRIPTION
also improved priceid-buy to know about helmets/gloves/boots.
Priceid-sell by default only displays stuff.
- set $sell_id_tab=1 to enable auto-nameing.
  It requires you to stand on an empty square, and is a bit scary - no guarantees!
  If it bugs out on you, please tell me, so I can try to improve it.
